### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://user-images.githubusercontent.com/59060246/219007436-a61f79be-e958-4426-
 
 - [eww](https://github.com/elkowar/eww)
 - xinput
-- dash ( optional )
+- dash
 
 ## Usage
 


### PR DESCRIPTION
Dash doesn't seem to be optional.

I'm on Fedora 37 where dash is not installed by default unlike it is on Ubuntu (not sure if that's where you live). 